### PR TITLE
feat(tailoring): add interactive resize dropdown and preserve chronological order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ dist-ssr
 .vercel
 .env*.local
 nul
+do_not_commit/

--- a/src/components/JobDetail/ResumeTailoringView.tsx
+++ b/src/components/JobDetail/ResumeTailoringView.tsx
@@ -28,7 +28,7 @@ import { autoTailorResume, refineTailoredResume, gradeResume, rewriteForMemory }
 import { isAIConfigured, generateId, getGradeColor } from '../../utils/helpers';
 import { exportMarkdownToPdf, generatePdfFilename } from '../../utils/pdfExport';
 import { showToast } from '../../stores/toastStore';
-import type { Job, TailoringEntry, SavedStory } from '../../types';
+import type { Job, TailoringEntry, SavedStory, ResumeTargetLength } from '../../types';
 
 interface ResumeTailoringViewProps {
   job: Job;
@@ -53,6 +53,7 @@ export function ResumeTailoringView({ job, onBack, initialKeyword }: ResumeTailo
   const [editedTailoredResume, setEditedTailoredResume] = useState('');
   const [savingMemoryEntryId, setSavingMemoryEntryId] = useState<string | null>(null);
   const [userMessage, setUserMessage] = useState('');
+  const [targetLength, setTargetLength] = useState<ResumeTargetLength | ''>('');
   const [viewMode, setViewMode] = useState<'tailored' | 'compare' | 'diff'>('tailored');
   const [keywordsExpanded, setKeywordsExpanded] = useState(true);
 
@@ -130,7 +131,9 @@ export function ResumeTailoringView({ job, onBack, initialKeyword }: ResumeTailo
       const { tailoredResume: newResume, changesSummary, suggestedQuestions } = await autoTailorResume(
         job.jdText,
         originalResume,
-        originalAnalysis
+        originalAnalysis,
+        job,
+        targetLength || undefined
       );
 
       // Auto-regrade the tailored resume
@@ -151,6 +154,45 @@ export function ResumeTailoringView({ job, onBack, initialKeyword }: ResumeTailo
         tailoredResumeAnalysis: newAnalysis,
         tailoringHistory: [assistantMessage],
         tailoringSuggestions: suggestedQuestions,
+      });
+    });
+  };
+
+  const handleResizeResume = async (newLength: ResumeTargetLength) => {
+    if (!hasAIConfigured || !originalAnalysis || refineOp.isLoading) return;
+
+    setTargetLength(newLength);
+    const resizeMessage = `Resize the resume to fit ${newLength}. Adjust content density accordingly.`;
+
+    const userEntry: TailoringEntry = {
+      id: generateId(),
+      role: 'user',
+      content: resizeMessage,
+      timestamp: new Date(),
+    };
+
+    const originalHistory = history;
+    await updateJob(job.id, {
+      tailoringHistory: [...history, userEntry],
+    });
+
+    await refineOp.execute(async () => {
+      const { reply, updatedResume } = await refineTailoredResume(
+        job.jdText, originalResume, tailoredResume, originalAnalysis,
+        originalHistory, resizeMessage, job, newLength
+      );
+
+      const assistantEntry: TailoringEntry = {
+        id: generateId(),
+        role: 'assistant',
+        content: reply,
+        resumeSnapshot: updatedResume,
+        timestamp: new Date(),
+      };
+
+      await updateJob(job.id, {
+        tailoredResume: updatedResume,
+        tailoringHistory: [...originalHistory, userEntry, assistantEntry],
       });
     });
   };
@@ -186,7 +228,9 @@ export function ResumeTailoringView({ job, onBack, initialKeyword }: ResumeTailo
         tailoredResume,
         originalAnalysis,
         originalHistory,
-        messageContent
+        messageContent,
+        job,
+        targetLength || undefined
       );
 
       const assistantEntry: TailoringEntry = {
@@ -323,6 +367,21 @@ export function ResumeTailoringView({ job, onBack, initialKeyword }: ResumeTailo
         </div>
 
         <div className="flex items-center gap-2">
+          {/* Target length selector (interactive post-tailoring) */}
+          {job.tailoredResume && !isEditing && (
+            <select
+              value={targetLength}
+              onChange={(e) => handleResizeResume(e.target.value as ResumeTargetLength)}
+              disabled={refineOp.isLoading}
+              className="text-xs border border-slate-200 dark:border-slate-700 rounded-lg px-2 py-1 bg-white dark:bg-slate-800 text-slate-600 dark:text-slate-400 focus:outline-none focus:ring-2 focus:ring-primary/50 disabled:opacity-50"
+              title="Change target length"
+            >
+              <option value="1 page">1 page</option>
+              <option value="2 pages">2 pages</option>
+              <option value="no limit">No limit</option>
+            </select>
+          )}
+
           {/* Grade comparison */}
           {originalAnalysis && tailoredAnalysis && (
             <div className="flex items-center gap-2 text-sm">
@@ -342,19 +401,31 @@ export function ResumeTailoringView({ job, onBack, initialKeyword }: ResumeTailo
           )}
 
           {!job.tailoredResume && (
-            <Button
-              onClick={handleAutoTailor}
-              disabled={autoTailorOp.isLoading || !hasAIConfigured}
-            >
-              {autoTailorOp.isLoading ? (
-                <AILoadingIndicator isLoading label="Tailoring..." />
-              ) : (
-                <>
-                  <Sparkles className="w-4 h-4 mr-1" />
-                  Auto-Tailor
-                </>
-              )}
-            </Button>
+            <>
+              <select
+                value={targetLength}
+                onChange={(e) => setTargetLength(e.target.value as ResumeTargetLength)}
+                className="text-sm border border-slate-200 dark:border-slate-700 rounded-lg px-2 py-1.5 bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-300 focus:outline-none focus:ring-2 focus:ring-primary/50"
+              >
+                <option value="" disabled>Max pages...</option>
+                <option value="1 page">1 page</option>
+                <option value="2 pages">2 pages</option>
+                <option value="no limit">No limit</option>
+              </select>
+              <Button
+                onClick={handleAutoTailor}
+                disabled={autoTailorOp.isLoading || !hasAIConfigured || !targetLength}
+              >
+                {autoTailorOp.isLoading ? (
+                  <AILoadingIndicator isLoading label="Tailoring..." />
+                ) : (
+                  <>
+                    <Sparkles className="w-4 h-4 mr-1" />
+                    Auto-Tailor
+                  </>
+                )}
+              </Button>
+            </>
           )}
 
           {job.tailoredResume && (
@@ -565,7 +636,7 @@ export function ResumeTailoringView({ job, onBack, initialKeyword }: ResumeTailo
           </div>
 
           {/* Suggested Prompts */}
-          {history.length > 0 && suggestedPrompts.length > 0 && !userMessage && (
+          {history.length > 0 && !userMessage && (
             <div className="px-3 pb-2">
               <div className="flex flex-wrap gap-1">
                 {suggestedPrompts.map((prompt, i) => (
@@ -577,6 +648,12 @@ export function ResumeTailoringView({ job, onBack, initialKeyword }: ResumeTailo
                     {prompt}
                   </button>
                 ))}
+                <button
+                  onClick={() => setUserMessage('Make the resume shorter and more concise. Remove less-relevant content to fit the target length.')}
+                  className="text-xs px-2 py-1 bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 rounded-full hover:bg-amber-200 dark:hover:bg-amber-900/50 transition-colors"
+                >
+                  Make it shorter
+                </button>
               </div>
             </div>
           )}

--- a/src/services/ai.ts
+++ b/src/services/ai.ts
@@ -33,7 +33,7 @@ import {
   GENERATE_TMAY_PROMPT,
   REFINE_PITCH_PROMPT,
 } from '../utils/prompts';
-import type { JobSummary, ResumeAnalysis, QAEntry, TailoringEntry, CoverLetterEntry, EmailDraftEntry, EmailType, ProviderType, ProviderSettings, Job, CareerCoachEntry, UserSkillProfile, SkillEntry, LearningTask, LearningTaskCategory, LearningTaskPrepMessage, SemanticCategoryResponse, Contact, InterviewerIntel, StoryTheme, PitchOutlineBlock } from '../types';
+import type { JobSummary, ResumeAnalysis, QAEntry, TailoringEntry, CoverLetterEntry, EmailDraftEntry, EmailType, ProviderType, ProviderSettings, Job, CareerCoachEntry, UserSkillProfile, SkillEntry, LearningTask, LearningTaskCategory, LearningTaskPrepMessage, SemanticCategoryResponse, Contact, InterviewerIntel, StoryTheme, PitchOutlineBlock, ResumeTargetLength } from '../types';
 import { generateId, decodeApiKey } from '../utils/helpers';
 import { useAppStore } from '../stores/appStore';
 import { getProvider, type AIMessage } from './providers';
@@ -395,7 +395,8 @@ export async function autoTailorResume(
   jdText: string,
   originalResume: string,
   resumeAnalysis: ResumeAnalysis,
-  job?: Job
+  job?: Job,
+  targetLength?: ResumeTargetLength
 ): Promise<{ tailoredResume: string; changesSummary: string; suggestedQuestions: string[] }> {
   // Use smart context with gap-focused queries if job is provided
   let additionalContext: string;
@@ -411,11 +412,17 @@ export async function autoTailorResume(
     additionalContext = getAdditionalContext();
   }
 
+  const additionalContextBlock = additionalContext.trim()
+    ? `REFERENCE MATERIAL (for content ideas only — do NOT include verbatim in the resume):\n${additionalContext}`
+    : '';
+
   const prompt = AUTO_TAILOR_PROMPT
     .replace('{jdText}', jdText)
-    .replace('{resumeText}', originalResume + additionalContext)
+    .replace('{resumeText}', originalResume)
     .replace('{gaps}', resumeAnalysis.gaps.join(', '))
-    .replace('{suggestions}', resumeAnalysis.suggestions.join(', '));
+    .replace('{suggestions}', resumeAnalysis.suggestions.join(', '))
+    .replace('{additionalContextBlock}', additionalContextBlock)
+    .replace('{targetLength}', targetLength || '2 pages');
 
   const response = await callAI([{ role: 'user', content: prompt }]);
   const jsonStr = extractJSON(response);
@@ -443,7 +450,8 @@ export async function refineTailoredResume(
   resumeAnalysis: ResumeAnalysis,
   history: TailoringEntry[],
   userMessage: string,
-  job?: Job
+  job?: Job,
+  targetLength?: ResumeTargetLength
 ): Promise<{ reply: string; updatedResume: string }> {
   // Use smart context with user message as query
   let additionalContext: string;
@@ -460,12 +468,18 @@ export async function refineTailoredResume(
     additionalContext = getAdditionalContext();
   }
 
+  const additionalContextBlock = additionalContext.trim()
+    ? `REFERENCE MATERIAL (for content ideas only — do NOT include verbatim in the resume):\n${additionalContext}`
+    : '';
+
   const systemPrompt = REFINE_RESUME_SYSTEM_PROMPT
     .replace('{jdText}', jdText)
-    .replace('{originalResume}', originalResume + additionalContext)
+    .replace('{originalResume}', originalResume)
     .replace('{currentResume}', currentTailoredResume)
     .replace('{gaps}', resumeAnalysis.gaps.join(', '))
-    .replace('{suggestions}', resumeAnalysis.suggestions.join(', '));
+    .replace('{suggestions}', resumeAnalysis.suggestions.join(', '))
+    .replace('{additionalContextBlock}', additionalContextBlock)
+    .replace('{targetLength}', targetLength || '2 pages');
 
   // Build message history
   const messages: AIMessage[] = [];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -226,6 +226,8 @@ export interface EmailDraftEntry {
 
 export type EmailType = 'thank-you' | 'follow-up' | 'withdraw' | 'negotiate' | 'custom';
 
+export type ResumeTargetLength = '1 page' | '2 pages' | 'no limit';
+
 // Workflow tracking types
 export type RejectionReason = 'ghosted' | 'skills_mismatch' | 'culture_fit' | 'salary' | 'position_filled' | 'other';
 // InterviewType is now a string to support custom types

--- a/src/utils/prompts.ts
+++ b/src/utils/prompts.ts
@@ -117,10 +117,27 @@ Resume Analysis (gaps and suggestions):
 Gaps: {gaps}
 Suggestions: {suggestions}
 
+{additionalContextBlock}
+
+LENGTH CONSTRAINT — HARD REQUIREMENT:
+Target: {targetLength}
+- "1 page": MUST fit one printed page. ~400-500 words max. Be ruthless about brevity.
+- "2 pages": MUST fit two printed pages. ~700-900 words max. Be concise but thorough.
+- "no limit": Use judgment, but still favor conciseness.
+
+CONCISENESS STRATEGY:
+- Most recent/relevant roles: 3-4 bullet points each
+- Older roles (5+ years ago): 1-2 bullet points or a single-line summary
+- Roles 8+ years ago: Consider omitting unless directly relevant to THIS job
+- Do NOT include a paragraph summary AND bullet points for the same role — pick one
+- Summary section: 2-3 sentences max, no sub-headings
+- Skills: only list skills mentioned in or relevant to this JD
+- NEVER reorder roles — always keep reverse-chronological order (most recent first)
+
 CRITICAL RULES:
 1. NEVER fabricate experience, skills, or achievements - only reframe what exists
 2. Use keywords and phrases from the job description where they honestly apply
-3. Reorder and emphasize relevant experience
+3. Emphasize relevant experience (but NEVER change the chronological order of roles — most recent first)
 4. Quantify achievements where possible using the candidate's actual experience
 5. Adjust skill descriptions to match JD terminology (if the skill is genuinely equivalent)
 6. When a "Learned Improvements from Previous Tailoring" section is provided in the context, apply relevant improvements - these are proven phrasings that worked well in past tailoring
@@ -129,7 +146,7 @@ Also generate 2-3 short, specific follow-up questions (under 60 chars each) that
 
 Return ONLY valid JSON with this exact structure:
 {
-  "tailoredResume": "Full markdown-formatted resume with all sections",
+  "tailoredResume": "Concise markdown resume within the target length",
   "changesSummary": "Brief bullet-point summary of key changes made",
   "suggestedQuestions": ["Short question 1?", "Short question 2?", "Short question 3?"]
 }
@@ -154,6 +171,17 @@ Current Tailored Resume:
 Resume Analysis:
 Gaps: {gaps}
 Suggestions: {suggestions}
+
+{additionalContextBlock}
+
+TARGET LENGTH: {targetLength}
+
+LENGTH AWARENESS:
+- Always respect the target length
+- If user asks to shorten: aggressively consolidate bullet points, remove less-relevant roles, merge similar items. Prioritize impact over completeness.
+- When adding new content, remove or condense less-relevant content to stay within target
+- A tight, relevant resume beats a comprehensive one
+- NEVER reorder roles — always keep reverse-chronological order (most recent first)
 
 Your role is to:
 1. Help the user address remaining gaps in their resume


### PR DESCRIPTION
Replace the static target-length badge with an interactive dropdown that triggers AI-powered resume resizing via the existing refinement flow. Add explicit constraints to both AUTO_TAILOR_PROMPT and REFINE_RESUME_SYSTEM_PROMPT to preserve reverse-chronological role ordering when condensing.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>